### PR TITLE
Add FastAPI example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-Nothing to write right now.
+# FastAPI Hello World
+
+This repository contains a minimal [FastAPI](https://fastapi.tiangolo.com/) application that returns a JSON greeting.
+
+## Setup
+
+1. It is recommended to use a virtual environment:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Running the app
+
+Start the server using `uvicorn`:
+
+```bash
+uvicorn main:app --reload
+```
+
+The application will be available at [http://127.0.0.1:8000/](http://127.0.0.1:8000/).
+Sending a `GET` request to the root path will return:
+
+```json
+{"message": "Hello World"}
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def read_root():
+    return {"message": "Hello World"}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
## Summary
- add a minimal FastAPI app that returns a greeting
- document installation and running instructions
- specify FastAPI and Uvicorn dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c7d64994833191bf1ae492f50594